### PR TITLE
Add a disgruntled employee card

### DIFF
--- a/config/cards/AdminsPicks_q.json
+++ b/config/cards/AdminsPicks_q.json
@@ -866,5 +866,12 @@
     "draw": 0,
     "pick": 1,
     "value": "If you could fuck anyone in the world, who would you choose?"
+  },
+  {
+    "type": "Question",
+    "keep": "Yes",
+    "draw": 0,
+    "pick": 1,
+    "value": "In a final act, a disgruntled support employee %s before leaving. "
   }
 ]


### PR DESCRIPTION
What it says. Because we can.

I'm also open to removing "in the database" if that would be better/funnier.
